### PR TITLE
Addapt to new sentry_sdk

### DIFF
--- a/sentry/requirements.txt
+++ b/sentry/requirements.txt
@@ -1,2 +1,1 @@
-raven
-raven-sanitize-openerp
+sentry-sdk

--- a/sentry/sentry.py
+++ b/sentry/sentry.py
@@ -43,11 +43,12 @@ def get_release():
 
 class Client(object):
 
-    def captureException(self):
+    @staticmethod
+    def captureException():
         sentry_sdk.capture_exception()
 
     @staticmethod
-    def captureMessage(self, message, level=None, scope=None, **scope_args):
+    def captureMessage(message, level=None, scope=None, **scope_args):
         sentry_sdk.capture_message(message, level, scope, scope_args)
 
 
@@ -102,7 +103,7 @@ class SentrySetup(osv.osv):
             logger.info('Setting up SENTRY_DSN=%s environment var', dsn)
         logger.info(
             'Sentry setup: release: %s, environment: %s, sample_rate: %s',
-            release, environment, traces_sample_rate
+            app_release, environment, traces_sample_rate
         )
         sentry_sdk.init(
             release=app_release,
@@ -111,7 +112,6 @@ class SentrySetup(osv.osv):
             before_send=begore_send,
             integrations=[RedisIntegration(), FlaskIntegration(), RqIntegration()]
         )
-        ignore_logger('openerp.web-services')
         self.client = Client()
         super(SentrySetup, self).__init__(pool, cursor)
 
@@ -119,6 +119,10 @@ class SentrySetup(osv.osv):
         if context is None:
             context = {}
         raise Exception('This is a sentry test exception')
+
+    def test_logger(self, cursor, uid, message, logger='openerp.sentry'):
+        test_logger = logging.getLogger(logger)
+        test_logger.error(message)
 
 
 SentrySetup()

--- a/sentry/sentry.py
+++ b/sentry/sentry.py
@@ -19,11 +19,25 @@ from signals import NETSVC_DISPATCH_EXCEPTION
 logger = logging.getLogger('openerp.sentry')
 
 
+class ExecuteInDir(object):
+    def __init__(self, d):
+        self.cd = os.getcwd()
+        self.d = d
+
+    def __enter__(self):
+        os.chdir(self.d)
+
+    def __exit__(self, *a, **kw):
+        os.chdir(self.cd)
+
+
 def get_release():
+    with ExecuteInDir(os.path.join(config['root_path'])):
+        git = subprocess.check_output(['git', 'describe', '--tags']).strip()
     return '{}@{}-{}'.format(
         release.name,
         release.version,
-        subprocess.check_output(['git', 'describe', '--tags']).strip()
+        git
     )
 
 

--- a/sentry/sentry.py
+++ b/sentry/sentry.py
@@ -93,7 +93,7 @@ class SentrySetup(osv.osv):
         dsn = config.get('sentry_dsn')
         app_release = get_release()
         environment = config.get('environment', 'staging')
-        sample_rate = float(config.get('sentry_sample_rate', 0))
+        traces_sample_rate = float(config.get('sentry_traces_sample_rate', 0))
         if dsn_env:
             config['sentry_dsn'] = dsn_env
             logger.info('Updating sentry_dsn=%s conf from environment var', dsn_env)
@@ -102,12 +102,12 @@ class SentrySetup(osv.osv):
             logger.info('Setting up SENTRY_DSN=%s environment var', dsn)
         logger.info(
             'Sentry setup: release: %s, environment: %s, sample_rate: %s',
-            release, environment, sample_rate
+            release, environment, traces_sample_rate
         )
         sentry_sdk.init(
             release=app_release,
             environment=environment,
-            traces_sample_rate=sample_rate,
+            traces_sample_rate=traces_sample_rate,
             before_send=begore_send,
             integrations=[RedisIntegration(), FlaskIntegration(), RqIntegration()]
         )

--- a/sentry/sentry.py
+++ b/sentry/sentry.py
@@ -3,36 +3,65 @@
 # this repository contains the full copyright notices and license terms.
 import os
 from osv import osv
-from tools import config
 import pooler
-import netsvc
-
-from raven import Client
-
-
-def log(msg, level=netsvc.LOG_INFO):
-    logger = netsvc.Logger()
-    logger.notifyChannel('sentry', netsvc.LOG_INFO, msg)
-
-
-class SentyDispatcherException(Exception):
-    def __init__(self, exception, traceback):
-        # Ugly hack to know wich type of exception it is.
-        # From client code: bin/rpc.py L:46
-        exc_type = unicode(exception).split(' -- ')[0]
-        # Predefined excptions from client code: bin/rpc.py L:177
-        if exc_type not in ('warning', 'UserError'):
-            if config.get('db_name', False):
-                sentry = pooler.get_pool(config['db_name']).get('sentry.setup')
-                if sentry:
-                    sentry.client.captureException()
-        self.exception = exception
-        self.traceback = traceback
+from tools import config
+import release
+import sentry_sdk
+from sentry_sdk.integrations.logging import ignore_logger
+from sentry_sdk.integrations.redis import RedisIntegration
+from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.integrations.rq import RqIntegration
+import subprocess
+import logging
+from signals import NETSVC_DISPATCH_EXCEPTION
 
 
-def monkeypatch():
-    log(u'Monkeypatching OpenERPDispatcherException!')
-    netsvc.OpenERPDispatcherException = SentyDispatcherException
+logger = logging.getLogger('openerp.sentry')
+
+
+def get_release():
+    return '{}@{}-{}'.format(
+        release.name,
+        release.version,
+        subprocess.check_output(['git', 'describe', '--tags']).strip()
+    )
+
+
+class Client(object):
+
+    @staticmethod
+    def captureException():
+        sentry_sdk.capture_exception()
+
+    @staticmethod
+    def captureMessage(message, level=None, scope=None, **scope_args):
+        sentry_sdk.capture_message(message, level, scope, scope_args)
+
+
+def send_to_sentry(dispatcher, service_name, method, params, exception):
+    # Ugly hack to know wich type of exception it is.
+    # From client code: bin/rpc.py L:46
+    exc_type = unicode(exception).split(' -- ')[0]
+    # Predefined excptions from client code: bin/rpc.py L:177
+    if exc_type not in ('warning', 'UserError'):
+        with sentry_sdk.configure_scope() as scope:
+            db, pool = pooler.get_db_and_pool(config['db_name'])
+            cursor = db.cursor()
+            user = pool.get('res.users').browse(cursor, 1, params[1])
+            scope.user = {
+                'id': params[1],
+                'username': user.login,
+                'name': user.name,
+                'email': user.address_id and user.address_id.email or None,
+                'ip_address': dispatcher.client_ip
+            }
+            cursor.close()
+            scope.set_tag('service_name', service_name),
+            scope.set_tag('method', method)
+            sentry_sdk.capture_exception(exception)
+
+
+NETSVC_DISPATCH_EXCEPTION.connect(send_to_sentry)
 
 
 class SentrySetup(osv.osv):
@@ -41,20 +70,35 @@ class SentrySetup(osv.osv):
     _name = 'sentry.setup'
 
     def __init__(self, pool, cursor):
-        processors = (
-            'raven.processors.SanitizePasswordsProcessor',
-            'raven_sanitize_openerp.OpenerpPasswordsProcessor'
-        )
         dsn_env = os.getenv('SENTRY_DSN')
         dsn = config.get('sentry_dsn')
+        release = get_release()
+        environment = config.get('environment', 'staging')
+        sample_rate = float(config.get('sentry_sample_rate', 0))
         if dsn_env:
             config['sentry_dsn'] = dsn_env
-            log('Updating sentry_dsn=%s conf from environment var' % dsn_env)
+            logger.info('Updating sentry_dsn=%s conf from environment var', dsn_env)
         elif dsn:
             os.environ['SENTRY_DSN'] = dsn
-            log('Setting up SENTRY_DSN=%s environment var' % dsn)
-        self.client = Client(processors=processors)
-        monkeypatch()
+            logger.info('Setting up SENTRY_DSN=%s environment var', dsn)
+        logger.info(
+            'Sentry setup: release: %s, environment: %s, sample_rate: %s',
+            release, environment, sample_rate
+        )
+        sentry_sdk.init(
+            release=release,
+            environment=environment,
+            traces_sample_rate=sample_rate,
+            integrations=[RedisIntegration(), FlaskIntegration(), RqIntegration()]
+        )
+        ignore_logger('openerp.web-services')
+        self.client = Client()
         super(SentrySetup, self).__init__(pool, cursor)
+
+    def test(self, cursor, uid, context=None):
+        if context is None:
+            context = {}
+        raise Exception('This is a sentry test exception')
+
 
 SentrySetup()


### PR DESCRIPTION
Add new sentry sdk version.

## New features

- Use traces sample rate to test performance with config `sentry_traces_sample_rate`
- Identify which user generated the exception
- Identify the version of the server
- Add the server environment from config `environment`
- Can test the values using `test()` from `sentry.setup` object

## Requires
- https://github.com/gisce/erp/pull/11281 New signals from netsvc server (we removed monkeypatched exception to improve message scope)

## Migration

- Remove  `SENTRY_DSN` environment in workers, it was configured to make *synchronous* connections with `https+sync` but now is not needed.